### PR TITLE
Blinded address support and sign on Liquid network

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,11 +32,16 @@ const App: React.FunctionComponent<Props> = () => {
             <div className="columns">
               {!state || !state.loaded ? (
                 <Load
-                  onLoad={(xpubOrAddress: string, selectedNetwork: any) => {
+                  onLoad={(
+                    xpubOrAddress: string,
+                    selectedNetwork: any,
+                    blindingPrivKey: string
+                  ) => {
                     setState({
                       loaded: true,
                       identity: xpubOrAddress,
                       network: selectedNetwork,
+                      blindingKey: blindingPrivKey,
                       ...state,
                     });
                   }}
@@ -45,6 +50,11 @@ const App: React.FunctionComponent<Props> = () => {
                 <Wallet
                   identity={state.identity}
                   network={state.network}
+                  blindingKey={
+                    state.blindingKey && state.blindingKey.length > 0
+                      ? state.blindingKey
+                      : undefined
+                  }
                   explorerUrl={state.explorerUrl}
                 />
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Load from './components/Load';
 import Wallet from './components/Wallet';
 import useGlobalStorage from 'use-global-storage';
 
-interface Props { }
+interface Props {}
 
 const App: React.FunctionComponent<Props> = () => {
   const useStorage = useGlobalStorage({
@@ -47,17 +47,17 @@ const App: React.FunctionComponent<Props> = () => {
                   }}
                 />
               ) : (
-                  <Wallet
-                    identity={state.identity}
-                    network={state.network}
-                    blindingKey={
-                      state.blindingKey && state.blindingKey.length > 0
-                        ? state.blindingKey
-                        : undefined
-                    }
-                    explorerUrl={state.explorerUrl}
-                  />
-                )}
+                <Wallet
+                  identity={state.identity}
+                  network={state.network}
+                  blindingKey={
+                    state.blindingKey && state.blindingKey.length > 0
+                      ? state.blindingKey
+                      : undefined
+                  }
+                  explorerUrl={state.explorerUrl}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Load from './components/Load';
 import Wallet from './components/Wallet';
 import useGlobalStorage from 'use-global-storage';
 
-interface Props {}
+interface Props { }
 
 const App: React.FunctionComponent<Props> = () => {
   const useStorage = useGlobalStorage({
@@ -47,17 +47,17 @@ const App: React.FunctionComponent<Props> = () => {
                   }}
                 />
               ) : (
-                <Wallet
-                  identity={state.identity}
-                  network={state.network}
-                  blindingKey={
-                    state.blindingKey && state.blindingKey.length > 0
-                      ? state.blindingKey
-                      : undefined
-                  }
-                  explorerUrl={state.explorerUrl}
-                />
-              )}
+                  <Wallet
+                    identity={state.identity}
+                    network={state.network}
+                    blindingKey={
+                      state.blindingKey && state.blindingKey.length > 0
+                        ? state.blindingKey
+                        : undefined
+                    }
+                    explorerUrl={state.explorerUrl}
+                  />
+                )}
             </div>
           </div>
         </div>

--- a/src/components/CreateTx.tsx
+++ b/src/components/CreateTx.tsx
@@ -31,15 +31,28 @@ const Create: React.FunctionComponent<Props> = props => {
     if (encoded.length === 0)
       return alert('Encode the transaction on every change before signing');
 
-    const mnemonic = prompt("What's your mnemonic? m/84'/0'/0'/0");
-    if (!Wallet.isValidMnemonic(mnemonic!)) return alert('Mnemonic not valid');
-
-    try {
-      const hex = wallet.signPsbtWithMnemonic(encoded, mnemonic!);
-      setEncoded(hex);
-    } catch (ignore) {
-      return alert(ignore);
+    const mnemonicOrWif = prompt('Enter your mnemonic or WIF private key');
+    if (Wallet.isValidMnemonic(mnemonicOrWif!)) {
+      try {
+        const hex = wallet.signPsbtWithMnemonic(encoded, mnemonicOrWif!);
+        setEncoded(hex);
+        return;
+      } catch (ignore) {
+        return alert(ignore);
+      }
     }
+
+    if (Wallet.isValidWIF(mnemonicOrWif!, currentNetwork)) {
+      try {
+        const hex = wallet.signPsbtWithPrivateKey(encoded, mnemonicOrWif!);
+        setEncoded(hex);
+        return;
+      } catch (ignore) {
+        return alert(ignore);
+      }
+    }
+
+    return alert('Mnemonic or WIF not valid');
   };
 
   return (

--- a/src/components/CreateTx.tsx
+++ b/src/components/CreateTx.tsx
@@ -7,16 +7,17 @@ import InputWithCopy from '../elements/InputWithCopy';
 
 interface Props {
   identity: string;
+  blindingKey?: string;
   network: string;
   utxos: Object;
   lbtc: string;
 }
 
 const Create: React.FunctionComponent<Props> = props => {
-  const { identity, network, lbtc, utxos } = props;
+  const { identity, network, lbtc, utxos, blindingKey } = props;
 
   const currentNetwork = (networks as any)[network];
-  const wallet = new Wallet(identity, currentNetwork);
+  const wallet = new Wallet(identity, currentNetwork, blindingKey);
 
   const [encoded, setEncoded] = useState('');
 

--- a/src/components/CreateTx.tsx
+++ b/src/components/CreateTx.tsx
@@ -31,7 +31,7 @@ const Create: React.FunctionComponent<Props> = props => {
     if (encoded.length === 0)
       return alert('Encode the transaction on every change before signing');
 
-    const mnemonic = prompt("What's your mnemonic?");
+    const mnemonic = prompt("What's your mnemonic? m/84'/0'/0'/0");
     if (!Wallet.isValidMnemonic(mnemonic!)) return alert('Mnemonic not valid');
 
     try {

--- a/src/components/DecodeTx.tsx
+++ b/src/components/DecodeTx.tsx
@@ -49,15 +49,28 @@ const Decode: React.FunctionComponent<Props> = props => {
     if (encoded.length === 0)
       return alert('Encode the transaction on every change before signing');
 
-    const mnemonic = prompt("What's your mnemonic? m/84'/0'/0'/0");
-    if (!Wallet.isValidMnemonic(mnemonic!)) return alert('Mnemonic not valid');
-
-    try {
-      const hex = wallet.signPsbtWithMnemonic(encoded, mnemonic!);
-      setEncoded(hex);
-    } catch (ignore) {
-      return alert(ignore);
+    const mnemonicOrWif = prompt('Enter your mnemonic or WIF private key');
+    if (Wallet.isValidMnemonic(mnemonicOrWif!)) {
+      try {
+        const hex = wallet.signPsbtWithMnemonic(encoded, mnemonicOrWif!);
+        setEncoded(hex);
+        return;
+      } catch (ignore) {
+        return alert(ignore);
+      }
     }
+
+    if (Wallet.isValidWIF(mnemonicOrWif!, currentNetwork)) {
+      try {
+        const hex = wallet.signPsbtWithPrivateKey(encoded, mnemonicOrWif!);
+        setEncoded(hex);
+        return;
+      } catch (ignore) {
+        return alert(ignore);
+      }
+    }
+
+    return alert('Mnemonic or WIF not valid');
   };
 
   return (

--- a/src/components/DecodeTx.tsx
+++ b/src/components/DecodeTx.tsx
@@ -7,16 +7,17 @@ import InputWithCopy from '../elements/InputWithCopy';
 
 interface Props {
   identity: string;
+  blindingKey?: string;
   network: string;
   utxos: Object;
   lbtc: string;
 }
 
 const Decode: React.FunctionComponent<Props> = props => {
-  const { identity, network, lbtc, utxos } = props;
+  const { identity, network, lbtc, utxos, blindingKey } = props;
 
   const currentNetwork = (networks as any)[network];
-  const wallet = new Wallet(identity, currentNetwork);
+  const wallet = new Wallet(identity, currentNetwork, blindingKey);
 
   const [state, setState] = useState({
     hasBeenDecoded: false,
@@ -48,7 +49,7 @@ const Decode: React.FunctionComponent<Props> = props => {
     if (encoded.length === 0)
       return alert('Encode the transaction on every change before signing');
 
-    const mnemonic = prompt("What's your mnemonic?");
+    const mnemonic = prompt("What's your mnemonic? m/84'/0'/0'/0");
     if (!Wallet.isValidMnemonic(mnemonic!)) return alert('Mnemonic not valid');
 
     try {

--- a/src/components/Load.tsx
+++ b/src/components/Load.tsx
@@ -125,7 +125,7 @@ const Load: React.FunctionComponent<Props> = props => {
           type="checkbox"
           className="switch is-medium is-link"
           checked={isLiquid}
-          onChange={() => { }}
+          onChange={() => {}}
         />
         <label className="label">{`${isLiquid ? 'Liquid' : 'Regtest'}`}</label>
       </div>

--- a/src/components/Load.tsx
+++ b/src/components/Load.tsx
@@ -125,7 +125,7 @@ const Load: React.FunctionComponent<Props> = props => {
           type="checkbox"
           className="switch is-medium is-link"
           checked={isLiquid}
-          onChange={() => {}}
+          onChange={() => { }}
         />
         <label className="label">{`${isLiquid ? 'Liquid' : 'Regtest'}`}</label>
       </div>
@@ -134,14 +134,14 @@ const Load: React.FunctionComponent<Props> = props => {
         ref={pubkey}
         className="input is-medium mb-6"
         onChange={(e: any) => onAddressInputChange(e.target.value)}
-        placeholder="Your segwit address here..."
+        placeholder="Your native segwit address here..."
       />
       {showBlinding && (
         <input
           type="text"
           ref={blindingPrivKey}
           className="input is-medium mb-6"
-          placeholder="Your private blinding key here..."
+          placeholder="Your private blinding key here (hex format)..."
         />
       )}
       <br />

--- a/src/components/Load.tsx
+++ b/src/components/Load.tsx
@@ -29,7 +29,7 @@ const Load: React.FunctionComponent<Props> = props => {
       !isValidXpub(pub, currentNetwork) &&
       !isValidAddress(pub, currentNetwork)
     )
-      return alert('Xpub or Segwit Address is not valid');
+      return alert('Given address is not a valid bech32 segwit address');
 
     props.onLoad(pub, networkString);
   };
@@ -98,7 +98,7 @@ const Load: React.FunctionComponent<Props> = props => {
         type="text"
         ref={pubkey}
         className="input is-medium"
-        placeholder="Your Segwit address here..."
+        placeholder="Your BECH32 segwit address here..."
       />
       <br />
       <br />

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -13,6 +13,7 @@ interface Props {
   identity: string;
   network: string;
   explorerUrl?: string;
+  blindingKey?: string;
 }
 
 interface State {
@@ -41,9 +42,13 @@ export default class Wallet extends React.Component<Props, State> {
   getBalances = () => {
     this.setState({ isLoading: true });
 
-    const { identity, network, explorerUrl } = this.props;
+    const { identity, network, explorerUrl, blindingKey } = this.props;
 
-    fetchBalances(identity, explorerUrl || (EXPLORER_URL as any)[network])
+    fetchBalances(
+      identity,
+      explorerUrl || (EXPLORER_URL as any)[network],
+      blindingKey
+    )
       .then((data: any) => {
         if (Object.keys(data.utxos).length > 0)
           this.setState({

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -43,7 +43,6 @@ export default class Wallet extends React.Component<Props, State> {
     this.setState({ isLoading: true });
 
     const { identity, network, explorerUrl, blindingKey } = this.props;
-
     fetchBalances(
       identity,
       explorerUrl || (EXPLORER_URL as any)[network],
@@ -109,7 +108,7 @@ export default class Wallet extends React.Component<Props, State> {
   };
 
   render() {
-    const { network, identity } = this.props;
+    const { network, identity, blindingKey } = this.props;
     const {
       showCreate,
       showImport,
@@ -208,6 +207,7 @@ export default class Wallet extends React.Component<Props, State> {
             lbtc={LBTC_ASSET_HASH}
             identity={identity}
             network={network}
+            blindingKey={blindingKey}
           />
         )}
         {!isLoading && showImport && (

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -7,7 +7,8 @@ import Balances from '../elements/Balances';
 import Spinner from '../elements/Spinner';
 
 import { fetchBalances, faucet, EXPLORER_URL, mint } from '../wallet';
-import { networks } from 'liquidjs-lib';
+import { networks, address } from 'liquidjs-lib';
+import TextWithCopy from '../elements/TextWithCopy';
 
 interface Props {
   identity: string;
@@ -123,7 +124,21 @@ export default class Wallet extends React.Component<Props, State> {
 
     return (
       <div className="column has-text-centered">
-        <h1 className="title is-4">{identity}</h1>
+        <TextWithCopy value={identity} textClass="title is-5" />
+
+        {blindingKey && (
+          <span>
+            <br />
+            <p className="title is-6">UNCONFIDENTIAL</p>
+            <TextWithCopy
+              value={address.fromConfidential(identity).unconfidentialAddress}
+              textClass="title is-5"
+            />
+            <br />
+            <br />
+          </span>
+        )}
+
         {!isLoading && hasBalances && (
           <Balances balances={balances} lbtc={LBTC_ASSET_HASH} />
         )}

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -216,6 +216,7 @@ export default class Wallet extends React.Component<Props, State> {
             lbtc={LBTC_ASSET_HASH}
             identity={identity}
             network={network}
+            blindingKey={blindingKey}
           />
         )}
       </div>

--- a/src/elements/TextWithCopy.tsx
+++ b/src/elements/TextWithCopy.tsx
@@ -4,6 +4,7 @@ import { copyToClipboard } from 'copy-lite';
 interface Props {
   value: string;
   label?: string;
+  textClass?: string;
 }
 export const TextWithCopy: React.FunctionComponent<Props> = props => {
   const [copySuccess, setCopySuccess] = useState('');
@@ -14,9 +15,11 @@ export const TextWithCopy: React.FunctionComponent<Props> = props => {
     setTimeout(() => setCopySuccess(''), 1500);
   };
 
+  const textClass = props.textClass ? props.textClass : 'subtitle';
+
   return (
     <span onClick={copy}>
-      <p className="subtitle">
+      <p className={textClass}>
         {props.label || props.value} {copySuccess}
       </p>
     </span>

--- a/src/helpers/inputs.ts
+++ b/src/helpers/inputs.ts
@@ -1,10 +1,19 @@
 import { address, Network, confidential, networks } from 'liquidjs-lib';
 
-export const validate = (
+function isValidConfidentialAddress(value: string): boolean {
+  try {
+    address.fromConfidential(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function validate(
   value: any,
   type: string,
   network: Network = networks.regtest
-): Boolean => {
+): boolean {
   switch (type) {
     case 'asset':
       if (value.length !== 64) {
@@ -13,8 +22,11 @@ export const validate = (
       return true;
     case 'address':
       try {
+        if (isValidConfidentialAddress(value))
+          throw new Error('Unconfidential only');
         if (value !== 'LBTC_FEES') address.toOutputScript(value, network);
       } catch (ignore) {
+        console.error(ignore);
         return false;
       }
       return true;
@@ -28,4 +40,4 @@ export const validate = (
     default:
       return false;
   }
-};
+}

--- a/src/helpers/xpub.ts
+++ b/src/helpers/xpub.ts
@@ -5,7 +5,7 @@
 */
 import b58 from 'bs58check';
 import * as bip32 from 'bip32';
-import { address, Network } from 'liquidjs-lib';
+import { address, Network, ECPair } from 'liquidjs-lib';
 
 const prefixes = new Map([
   ['xpub', '0488b21e'],
@@ -67,4 +67,13 @@ export function isValidAddress(value: string, network: Network) {
   }
 
   return true;
+}
+
+export function isValidBlindingKey(value: string): boolean {
+  try {
+    ECPair.fromPrivateKey(Buffer.from(value, 'hex'));
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -35,12 +35,14 @@ export default class LiquidWallet {
     try {
       address.toOutputScript(identity, network);
       if (blindingKey && !isValidBlindingKey)
-        throw new Error("Invalid blinding key");
+        throw new Error('Invalid blinding key');
     } catch (ignore) {
       throw new Error('Invalid address');
     }
 
-    const payOpts = blindingKey ? { confidentialAddress: identity } : { address: identity };
+    const payOpts = blindingKey
+      ? { confidentialAddress: identity }
+      : { address: identity };
     const payment = payments.p2wpkh({ ...payOpts, network });
     this.scriptPubKey = payment.output!.toString('hex');
     this.address = payment.address!;
@@ -191,7 +193,11 @@ export function fetchUtxos(address: string, url: string): Promise<any> {
   return fetch(`${url}/address/${address}/utxo`).then(r => r.json());
 }
 
-export async function unblindUtxos(utxos: Array<any>, blindingKey: string, url: string) {
+export async function unblindUtxos(
+  utxos: Array<any>,
+  blindingKey: string,
+  url: string
+) {
   const promises = utxos.map(utxo =>
     fetch(`${url}/tx/${utxo.txid}/hex`)
       .then(r => r.text())
@@ -221,7 +227,6 @@ export async function unblindUtxos(utxos: Array<any>, blindingKey: string, url: 
     throw e;
   }
 }
-
 
 export function faucet(address: string, url: string): Promise<any> {
   return fetch(`${url}/faucet`, {
@@ -296,5 +301,3 @@ export async function fetchBalances(
     utxos,
   };
 }
-
-

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -210,9 +210,12 @@ export function mint(
 }
 export async function fetchBalances(
   address: string,
-  url: string
+  url: string,
+  blindingKey?: string
 ): Promise<any> {
-  const fetchedData = await fetchUtxos(address, url);
+  const fetchedData = (await fetchUtxos(address, url)).map((utxo: any) => {
+    return utxo;
+  });
   const balances = fetchedData.reduce(
     (storage: { [x: string]: any }, item: { [x: string]: any; value: any }) => {
       // get the first instance of the key by which we're grouping


### PR DESCRIPTION
This adds blinding support (only reading), the possibility to specify the fee output at creation time and the possibility to generate a mnemonic and sign transaction also on Liquid mainnet.