### PR TITLE
Expect many inputs with same script to be signed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "author": "Vulpem Ventures",
   "browserslist": [
     "last 2 versions",
-    "not dead"
+    "not dead",
+    "not op_mob > 1"
   ],
   "module": "dist/liquid.coach.esm.js",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,9 +2173,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043:
-  version "1.0.30001046"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001046.tgz#7a06d3e8fd8aa7f4d21c9a2e313f35f2d06b013e"
-  integrity sha512-CsGjBRYWG6FvgbyGy+hBbaezpwiqIOLkxQPY4A4Ea49g1eNsnQuESB+n4QM0BKii1j80MyJ26Ir5ywTQkbRE4g==
+  version "1.0.30001148"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
+  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
before this commit the sign function would have assumed a single input to be signed corrsponding the keypair passed. Now we loop all possible inputs and we try to sign, skipping eventual errors (ie. inputs to be signed by different key pairs)



Changelog
﻿- bump browserlist
- Expect many inputs with same script to be signed


this closes #12 